### PR TITLE
[RISCV] Support for Ibex pointer authentication

### DIFF
--- a/clang/lib/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CodeGen/TargetInfo.cpp
@@ -10552,6 +10552,18 @@ public:
     const auto *FD = dyn_cast_or_null<FunctionDecl>(D);
     if (!FD) return;
 
+    auto *Fn = cast<llvm::Function>(GV);
+
+    // Add sign-return-address attribute to function
+    LangOptions::SignReturnAddressScopeKind Scope =
+        CGM.getLangOpts().getSignReturnAddressScope();
+    if (Scope != LangOptions::SignReturnAddressScopeKind::None) {
+      Fn->addFnAttr("sign-return-address",
+                    Scope == LangOptions::SignReturnAddressScopeKind::All
+                        ? "all"
+                        : "non-leaf");
+    }
+
     const auto *Attr = FD->getAttr<RISCVInterruptAttr>();
     if (!Attr)
       return;
@@ -10562,8 +10574,6 @@ public:
     case RISCVInterruptAttr::supervisor: Kind = "supervisor"; break;
     case RISCVInterruptAttr::machine: Kind = "machine"; break;
     }
-
-    auto *Fn = cast<llvm::Function>(GV);
 
     Fn->addFnAttr("interrupt", Kind);
   }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2018,6 +2018,25 @@ void Clang::AddRISCVTargetArgs(const ArgList &Args,
   CmdArgs.push_back(ABIName.data());
 
   SetRISCVSmallDataLimit(getToolChain(), Args, CmdArgs);
+
+  // Enable/disable return address signing.
+  if (Arg *A = Args.getLastArg(options::OPT_msign_return_address_EQ)) {
+
+    const Driver &D = getToolChain().getDriver();
+
+    StringRef Scope;
+
+    if (A->getOption().matches(options::OPT_msign_return_address_EQ)) {
+      Scope = A->getValue();
+      if (!Scope.equals("none") && !Scope.equals("non-leaf") &&
+          !Scope.equals("all"))
+        D.Diag(diag::err_invalid_branch_protection)
+            << Scope << A->getAsString(Args);
+    }
+
+    CmdArgs.push_back(
+        Args.MakeArgString(Twine("-msign-return-address=") + Scope));
+  }
 }
 
 void Clang::AddSparcTargetArgs(const ArgList &Args,

--- a/clang/test/CodeGen/riscv32-sign-return-address.c
+++ b/clang/test/CodeGen/riscv32-sign-return-address.c
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -triple riscv32 -S -emit-llvm -o - -msign-return-address=none  %s | FileCheck %s --check-prefix=CHECK-NONE
+// RUN: %clang_cc1 -triple riscv32 -S -emit-llvm -o - -msign-return-address=non-leaf %s | FileCheck %s --check-prefix=CHECK-PARTIAL
+// RUN: %clang_cc1 -triple riscv32 -S -emit-llvm -o - -msign-return-address=all %s | FileCheck %s --check-prefix=CHECK-ALL
+
+// CHECK-NONE: @foo() #[[ATTR:[0-9]*]]
+// CHECK-NONE-NOT: attributes #[[ATTR]] = { {{.*}} "sign-return-address"={{.*}} }}
+
+// CHECK-PARTIAL: @foo() #[[ATTR:[0-9]*]]
+// CHECK-PARTIAL: attributes #[[ATTR]] = { {{.*}} "sign-return-address"="non-leaf" {{.*}}}
+
+// CHECK-ALL: @foo() #[[ATTR:[0-9]*]]
+// CHECK-ALL: attributes #[[ATTR]] = { {{.*}} "sign-return-address"="all" {{.*}} }
+
+void foo() {}

--- a/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVFrameLowering.cpp
@@ -117,6 +117,29 @@ getRestoreLibCallName(const MachineFunction &MF,
   return RestoreLibCalls[LibCallID];
 }
 
+static bool shouldSignReturnAddress(const MachineFunction &MF) {
+  // The function should be signed in the following situations:
+  // - sign-return-address=all and RV32
+  // - sign-return-address=non-leaf and the functions spills the
+  //   X1(return address) and RV32
+
+  RISCVSubtarget::SignReturnAddress attr = RISCVSubtarget::checkSignReturnAddress(MF);
+
+  if (attr == RISCVSubtarget::NONE)
+    return false;
+
+  if (attr == RISCVSubtarget::ALL)
+    return true;
+
+  assert(attr == RISCVSubtarget::NON_LEAF && "Expected all, none or non-leaf");
+
+  for (const auto &Info : MF.getFrameInfo().getCalleeSavedInfo())
+    if (Info.getReg() == RISCV::X1) // Return address register
+      return true;
+
+  return false;
+}
+
 bool RISCVFrameLowering::hasFP(const MachineFunction &MF) const {
   const TargetRegisterInfo *RegInfo = MF.getSubtarget().getRegisterInfo();
 
@@ -264,6 +287,16 @@ void RISCVFrameLowering::emitPrologue(MachineFunction &MF,
   uint64_t StackSize = MFI.getStackSize();
   uint64_t RealStackSize = StackSize + RVFI->getLibCallStackSize();
 
+  // Using the stack pointer as the context, generate pointer authentication
+  // code for the return address and store it to X31. We need to generate
+  // the pointer authentication code and translate the return address into
+  // an incorrect address before the return address is saved in memory.
+  if (shouldSignReturnAddress(MF)) {
+    MBB.addLiveIn(RISCV::X31);
+    BuildMI(MBB, MBBI, DL, TII->get(RISCV::PAC), RISCV::X31)
+        .addReg(RISCV::X1, RegState::Define).addReg(RISCV::X1).addReg(SPReg);
+  }
+
   // Early exit if there is no need to allocate on the stack
   if (RealStackSize == 0 && !MFI.adjustsStack())
     return;
@@ -393,6 +426,7 @@ void RISCVFrameLowering::emitPrologue(MachineFunction &MF,
 void RISCVFrameLowering::emitEpilogue(MachineFunction &MF,
                                       MachineBasicBlock &MBB) const {
   const RISCVRegisterInfo *RI = STI.getRegisterInfo();
+  const RISCVInstrInfo *TII = STI.getInstrInfo();
   MachineFrameInfo &MFI = MF.getFrameInfo();
   auto *RVFI = MF.getInfo<RISCVMachineFunctionInfo>();
   Register FPReg = getFPReg(STI);
@@ -457,6 +491,15 @@ void RISCVFrameLowering::emitEpilogue(MachineFunction &MF,
 
   // Deallocate stack
   adjustReg(MBB, MBBI, DL, SPReg, SPReg, StackSize, MachineInstr::FrameDestroy);
+
+  // Verify the value of the return address stored in X1, using the stack
+  // pointer as context and the pointer authentication code in X31. We need
+  // to verify the return address and (if successful) return it to the
+  // correct value before executing ret instruction.
+  if (shouldSignReturnAddress(MF)) {
+    BuildMI(MBB, MBBI, DL, TII->get(RISCV::AUT), RISCV::X1)
+        .addReg(RISCV::X1).addReg(RISCV::X31).addReg(SPReg);
+  }
 }
 
 int RISCVFrameLowering::getFrameIndexReference(const MachineFunction &MF,

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -1936,6 +1936,18 @@ static bool CC_RISCV_FastCC(unsigned ValNo, MVT ValVT, MVT LocVT,
   return true; // CC didn't match.
 }
 
+static bool shouldSaveOrLoadPAC(const MachineFunction &MF) {
+  // The function should save/load a register to store pointer authentication code
+  // in the following situations:
+  // - sign-return-address=all
+  // - sign-return-address=non-leaf
+
+  if (RISCVSubtarget::checkSignReturnAddress(MF) == RISCVSubtarget::NONE)
+    return false;
+  else
+    return true;
+}
+
 // Transform physical registers into virtual registers.
 SDValue RISCVTargetLowering::LowerFormalArguments(
     SDValue Chain, CallingConv::ID CallConv, bool IsVarArg,
@@ -2150,6 +2162,12 @@ bool RISCVTargetLowering::isEligibleForTailCallOptimization(
     if (Arg.Flags.isByVal())
       return false;
 
+  // Pointer Authentication
+  const Function &F = MF.getFunction();
+  RISCVSubtarget::SignReturnAddress attr = RISCVSubtarget::checkSignReturnAddress(MF);
+  if (attr == RISCVSubtarget::ALL || attr == RISCVSubtarget::NON_LEAF)
+    return false;
+
   return true;
 }
 
@@ -2190,6 +2208,19 @@ SDValue RISCVTargetLowering::LowerCall(CallLoweringInfo &CLI,
   else if (CLI.CB && CLI.CB->isMustTailCall())
     report_fatal_error("failed to perform tail call elimination on a call "
                        "site marked musttail");
+
+  // Save X31 onto the stack if function call overwrites X31(which is used
+  // as a register to store pointer authentication code) for Ibex pointer
+  // authentication.
+  SDValue PACSpillSlot;
+  int PACFI;
+  if (shouldSaveOrLoadPAC(MF)) {
+    SDValue Val = DAG.getRegister(RISCV::X31, XLenVT);
+    PACSpillSlot = DAG.CreateStackTemporary(TypeSize(4, false), Align(4));
+    PACFI = cast<FrameIndexSDNode>(PACSpillSlot)->getIndex();
+    Chain = DAG.getStore(Chain, DL, Val, PACSpillSlot,
+                         MachinePointerInfo::getFixedStack(MF, PACFI));
+  }
 
   // Get a count of how many bytes are to be pushed on the stack.
   unsigned NumBytes = ArgCCInfo.getNextStackOffset();
@@ -2425,6 +2456,15 @@ SDValue RISCVTargetLowering::LowerCall(CallLoweringInfo &CLI,
     RetValue = convertLocVTToValVT(DAG, RetValue, VA, DL);
 
     InVals.push_back(RetValue);
+  }
+
+  // Load X31 from the stack if function call overwrites X31(which is used
+  // as a register to store pointer authentication code) for Ibex pointer
+  // authentication.
+  if (shouldSaveOrLoadPAC(MF)) {
+    SDValue Val = DAG.getLoad(XLenVT, DL, Chain, PACSpillSlot,
+                              MachinePointerInfo::getFixedStack(MF, PACFI));
+    Chain = DAG.getCopyToReg(Chain, DL, RISCV::X31, Val);
   }
 
   return Chain;

--- a/llvm/lib/Target/RISCV/RISCVInstrFormats.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrFormats.td
@@ -75,6 +75,7 @@ def OPC_BRANCH    : RISCVOpcode<0b1100011>;
 def OPC_JALR      : RISCVOpcode<0b1100111>;
 def OPC_JAL       : RISCVOpcode<0b1101111>;
 def OPC_SYSTEM    : RISCVOpcode<0b1110011>;
+def OPC_CUSTOM0   : RISCVOpcode<0b0001011>;
 
 class RVInst<dag outs, dag ins, string opcodestr, string argstr,
              list<dag> pattern, InstFormat format>

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -552,6 +552,48 @@ def SRAW  : ALUW_rr<0b0100000, 0b101, "sraw">,
 } // Predicates = [IsRV64]
 
 //===----------------------------------------------------------------------===//
+// Custom instructions for Ibex pointer authentication
+//===----------------------------------------------------------------------===//
+
+// This instruction computes a pointer authentication code for a pointer,
+// using a context and key, and stores the pointer authentication code to
+// a general register. Also, the upper bits of the pointer are rewritten to
+// an invalid address and the upper bits of the pointer are stored in the
+// upper bits of the register that stores the pointer authentication code.
+// PAC <rd>, <rs1>, <rs2>
+// - The pointer is in the general-purpose register that is specified by <rs1>.
+// - The context is in the general-purpose register that is specified by <rs2>.
+// - The upper bits of the pointer that is specified by <rs1> are rewritten.
+// - The generated pointer authenticaiotn code is stored in the general-purpose
+//   register that is specified by <rd>.
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def PAC
+    : RVInstR<0b0000000, 0b000, OPC_CUSTOM0, (outs GPR:$rd, GPR:$rs1_wb),
+              (ins GPR:$rs1, GPR:$rs2), "pac", "$rd, $rs1, $rs2">, Sched<[]> {
+    let Constraints = "$rs1 = $rs1_wb";
+}
+
+// This instruction authenticates a pointer, using a context and key. If the
+// authentication is successful, the upper bits of pointer are rewritten to
+// the original value. If it fails, the upper bits of pointer are not rewritten,
+// so it is expected that an error will occur when using the pointer later.
+// Also, this instruction does not cause an exception, so it has no side effects.
+// AUT <rd>, <rs1>, <rs2>, <rs3>
+// - The lower bits of pointer are in the general-purpose register that is
+//   specified by <rs1>.
+// - The pointer authentication code and the upper bits of pointer is in
+//   the general-purpose register that is specified by <rs2>.
+// - The context is in the general-purpose register that is specified by <rs3>.
+// - The authenticated pointer is stored in the general-purpose register that is
+//   specified by <rd>.
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def AUT
+    : RVInstR4<0b00, OPC_CUSTOM0, (outs GPR:$rd),
+              (ins GPR:$rs1, GPR:$rs2, GPR:$rs3), "aut", "$rd, $rs1, $rs2, $rs3">, Sched<[]> {
+    let Inst{14-12} = 0b001; // func3
+}
+
+//===----------------------------------------------------------------------===//
 // Privileged instructions
 //===----------------------------------------------------------------------===//
 

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
@@ -77,3 +77,27 @@ const LegalizerInfo *RISCVSubtarget::getLegalizerInfo() const {
 const RegisterBankInfo *RISCVSubtarget::getRegBankInfo() const {
   return RegBankInfo.get();
 }
+
+RISCVSubtarget::SignReturnAddress RISCVSubtarget::checkSignReturnAddress(const MachineFunction &MF) {
+  const Function &F = MF.getFunction();
+  if (!F.hasFnAttribute("sign-return-address"))
+    return NONE;
+
+  StringRef Scope = F.getFnAttribute("sign-return-address").getValueAsString();
+  if (Scope.equals("none"))
+      return NONE;
+
+  // Only 32bit RISCV is supported
+  auto &Subtarget = MF.getSubtarget<RISCVSubtarget>();
+  if (Subtarget.getTargetABI() != RISCVABI::ABI_ILP32)
+    llvm_unreachable("Unsupported ABI");
+
+  if (Scope.equals("all"))
+    return ALL;
+
+  if (Scope.equals("non-leaf"))
+    return NON_LEAF;
+
+  assert("Expected all, none or non-leaf");
+  return NONE;
+}

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -135,6 +135,14 @@ public:
   InstructionSelector *getInstructionSelector() const override;
   const LegalizerInfo *getLegalizerInfo() const override;
   const RegisterBankInfo *getRegBankInfo() const override;
+
+  enum SignReturnAddress {
+    ALL,
+    NON_LEAF,
+    NONE
+  };
+
+  static SignReturnAddress checkSignReturnAddress(const MachineFunction &MF);
 };
 } // End llvm namespace
 

--- a/llvm/lib/Target/RISCV/RISCVSystemOperands.td
+++ b/llvm/lib/Target/RISCV/RISCVSystemOperands.td
@@ -310,6 +310,9 @@ def: SysReg<"mhpmcounter31h", 0xB9F>;
 //===--------------------------
 // Machine Counter Setup
 //===--------------------------
+let AltName = "mucounteren" in
+def : SysReg<"mcountinhibit", 0x320>;
+
 def : SysReg<"mhpmevent3", 0x323>;
 def : SysReg<"mhpmevent4", 0x324>;
 def : SysReg<"mhpmevent5", 0x325>;

--- a/llvm/test/CodeGen/RISCV/sign-return-address.ll
+++ b/llvm/test/CodeGen/RISCV/sign-return-address.ll
@@ -1,0 +1,66 @@
+; RUN: llc -mtriple=riscv32 -verify-machineinstrs < %s \
+; RUN:   | FileCheck %s -check-prefix=RV32I
+
+define i32 @leaf(i32 %x) {
+; RV32I-LABEL: leaf:
+; RV32I-NOT: pac t6, ra, sp
+; RV32I-NOT: sw t6, {{[0-9]+}}(sp)
+; RV32I-NOT: lw t6, {{[0-9]+}}(sp)
+; RV32I-NOT: aut ra, ra, t6, sp
+; RV32I: ret
+  ret i32 %x
+}
+
+define i32 @leaf_sign_none(i32 %x) "sign-return-address"="none" {
+; RV32I-LABEL: leaf_sign_none:
+; RV32I-NOT: pac t6, ra, sp
+; RV32I-NOT: sw t6, {{[0-9]+}}(sp)
+; RV32I-NOT: lw t6, {{[0-9]+}}(sp)
+; RV32I-NOT: aut ra, ra, t6, sp
+; RV32I: ret
+  ret i32 %x
+}
+
+define i32 @leaf_sign_non_leaf(i32 %x) "sign-return-address"="non-leaf" {
+; RV32I-LABEL: leaf_sign_non_leaf:
+; RV32I-NOT: pac t6, ra, sp
+; RV32I-NOT: sw t6, {{[0-9]+}}(sp)
+; RV32I-NOT: lw t6, {{[0-9]+}}(sp)
+; RV32I-NOT: aut ra, ra, t6, sp
+; RV32I: ret
+  ret i32 %x
+}
+
+define i32 @leaf_sign_all(i32 %x) "sign-return-address"="all" {
+; RV32I-LABEL: leaf_sign_all:
+; RV32I: pac t6, ra, sp
+; RV32I-NOT: sw t6, {{[0-9]+}}(sp)
+; RV32I-NOT: lw t6, {{[0-9]+}}(sp)
+; RV32I: aut ra, ra, t6, sp
+; RV32I-NEXT: ret
+  ret i32 %x
+}
+
+declare i32 @foo(i32)
+
+define i32 @non_leaf_sign_all(i32 %x) "sign-return-address"="all" {
+; RV32I-LABEL: non_leaf_sign_all:
+; RV32I: pac t6, ra, sp
+; RV32I: sw t6, {{[0-9]+}}(sp)
+; RV32I: lw t6, {{[0-9]+}}(sp)
+; RV32I: aut ra, ra, t6, sp
+; RV32I-NEXT: ret
+  %call = call i32 @foo(i32 %x)
+  ret i32 %call
+}
+
+define i32 @non_leaf_sign_non_leaf(i32 %x) "sign-return-address"="non-leaf" {
+; RV32I-LABEL: non_leaf_sign_non_leaf:
+; RV32I: pac t6, ra, sp
+; RV32I: sw t6, {{[0-9]+}}(sp)
+; RV32I: lw t6, {{[0-9]+}}(sp)
+; RV32I: aut ra, ra, t6, sp
+; RV32I-NEXT: ret
+  %call = call i32 @foo(i32 %x)
+  ret i32 %call
+}

--- a/llvm/test/MC/RISCV/machine-csr-names.s
+++ b/llvm/test/MC/RISCV/machine-csr-names.s
@@ -849,6 +849,34 @@ csrrs t2, 0xB1F, zero
 ######################################
 # Machine Counter Setup
 ######################################
+# mcountinhibit
+# name
+# CHECK-INST: csrrs t1, mcountinhibit, zero
+# CHECK-ENC:  encoding: [0x73,0x23,0x00,0x32]
+# CHECK-INST-ALIAS: csrr t1, mcountinhibit
+# uimm12
+# CHECK-INST: csrrs t2, mcountinhibit, zero
+# CHECK-ENC:  encoding: [0xf3,0x23,0x00,0x32]
+# CHECK-INST-ALIAS: csrr t2, mcountinhibit
+# name
+csrrs t1, mcountinhibit, zero
+# uimm12
+csrrs t2, 0x320, zero
+
+# mucounteren
+# name
+# CHECK-INST: csrrs t1, mcountinhibit, zero
+# CHECK-ENC:  encoding: [0x73,0x23,0x00,0x32]
+# CHECK-INST-ALIAS: csrr t1, mcountinhibit
+# uimm12
+# CHECK-INST: csrrs t2, mcountinhibit, zero
+# CHECK-ENC:  encoding: [0xf3,0x23,0x00,0x32]
+# CHECK-INST-ALIAS: csrr t2, mcountinhibit
+# name
+csrrs t1, mucounteren, zero
+# uimm12
+csrrs t2, 0x320, zero
+
 # mhpmevent3
 # name
 # CHECK-INST: csrrs t1, mhpmevent3, zero

--- a/llvm/test/MC/RISCV/rv32-signed-pointer.s
+++ b/llvm/test/MC/RISCV/rv32-signed-pointer.s
@@ -1,0 +1,14 @@
+# RUN: llvm-mc %s -triple=riscv32 -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK-INST,CHECK-ENC %s
+
+# CHECK-INST: pac t6, ra, sp
+# CHECK-ENC: # encoding:  [0x8b,0x8f,0x20,0x00]
+# pac rd, rs1, rs2
+# R-Type: 0000000_00010_00001_000_11111_0001011
+pac t6, ra, sp
+
+# CHECK-INST: aut ra, ra, t6, sp
+# CHECK-ENC: # encoding:  [0x8b,0x90,0xf0,0x11]
+# aut rd, rs1, rs2, rs3
+# R4-Type: 00010_00_11111_00001_001_00001_0001011
+aut ra, ra, t6, sp


### PR DESCRIPTION
We are working on GSoC2020 project to implement pointer authentication in Ibex. I added the following features.

- Add assembler and disassembler support for Ibex pointer authentication instructions.
- Generate pointer authentication instructions.
    - Function prologue specified by the attribute signs the return-address before spilling the return address to the stack.
    - Function epilogues specified by the attribute authenticates when the return address is restored from stack.
- Save to and load from the stack when the X31 register used to save the pointer authentication code  is overwritten by function call.
- Generate function attributes that signal to the back whether return address signing instruction should be added, depending on a command line option (-msign-return-address)


I used the following command to confirm that the added function does not affect other functions and that the added pointer authentication is working properly. I also build llvm according to [Building LLVM](https://github.com/lowRISC/lowrisc-site/blob/master/content/llvm/devmtg18.md#building-llvm).
```
$ ./bin/llvm-lit -s -i test/CodeGen/RISCV test/MC/RISCV                                                                                                                      

Testing Time: 27.89s
  Passed: 366
```

~~Also, when you compile Ibex's Simple System with this llvm, you need to make the following changes to `lib/Target/RISCV/RISCVSystemOperands.td`.~~
I included a patch for AltName in the commit.
```
diff --git a/llvm/lib/Target/RISCV/RISCVSystemOperands.td b/llvm/lib/Target/RISCV/RISCVSystemOperands.td
index 853dca0295c..893bd259b80 100644
--- a/llvm/lib/Target/RISCV/RISCVSystemOperands.td
+++ b/llvm/lib/Target/RISCV/RISCVSystemOperands.td
@@ -310,6 +310,9 @@ def: SysReg<"mhpmcounter31h", 0xB9F>;
 //===--------------------------
 // Machine Counter Setup
 //===--------------------------
+def : SysReg<"mcountinhibit", 0x320> {
+  let AltName = "mucounteren";
+}
 def : SysReg<"mhpmevent3", 0x323>;
 def : SysReg<"mhpmevent4", 0x324>;
 def : SysReg<"mhpmevent5", 0x325>;
```
