### PR TITLE
Add ePIC relocation model to the C API

### DIFF
--- a/llvm/include/llvm-c/TargetMachine.h
+++ b/llvm/include/llvm-c/TargetMachine.h
@@ -40,6 +40,7 @@ typedef enum {
     LLVMRelocStatic,
     LLVMRelocPIC,
     LLVMRelocDynamicNoPic,
+    LLVMRelocEPIC,
     LLVMRelocROPI,
     LLVMRelocRWPI,
     LLVMRelocROPI_RWPI

--- a/llvm/lib/Target/TargetMachineC.cpp
+++ b/llvm/lib/Target/TargetMachineC.cpp
@@ -114,6 +114,9 @@ LLVMTargetMachineRef LLVMCreateTargetMachine(LLVMTargetRef T,
     case LLVMRelocDynamicNoPic:
       RM = Reloc::DynamicNoPIC;
       break;
+    case LLVMRelocEPIC:
+      RM = Reloc::EPIC;
+      break;
     case LLVMRelocROPI:
       RM = Reloc::ROPI;
       break;


### PR DESCRIPTION
This change adds ePIC support to llvm's C-API.
This is needed to add ePIC support to `rustc`.