### PR TITLE
[ELF] Backport overflow check fixes

### DIFF
--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -909,7 +909,12 @@ std::pair<MemoryRegion *, MemoryRegion *>
 LinkerScript::findMemoryRegion(OutputSection *sec, MemoryRegion *hint) {
   // Non-allocatable sections are not part of the process image.
   if (!(sec->flags & SHF_ALLOC)) {
-    if (!sec->memoryRegionName.empty())
+    bool hasInputOrByteCommand =
+        sec->hasInputSections ||
+        llvm::any_of(sec->commands, [](SectionCommand *comm) {
+          return ByteCommand::classof(comm);
+        });
+    if (!sec->memoryRegionName.empty() && hasInputOrByteCommand)
       warn("ignoring memory region assignment for non-allocatable section '" +
            sec->name + "'");
     return {nullptr, nullptr};

--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -157,12 +157,6 @@ OutputDesc *LinkerScript::getOrCreateOutputSection(StringRef name) {
 static void expandMemoryRegion(MemoryRegion *memRegion, uint64_t size,
                                StringRef secName) {
   memRegion->curPos += size;
-  uint64_t newSize = memRegion->curPos - (memRegion->origin)().getValue();
-  uint64_t length = (memRegion->length)().getValue();
-  if (newSize > length)
-    error("section '" + secName + "' will not fit in region '" +
-          memRegion->name + "': overflowed by " + Twine(newSize - length) +
-          " bytes");
 }
 
 void LinkerScript::expandMemoryRegions(uint64_t size) {
@@ -1431,4 +1425,24 @@ SmallVector<size_t, 0> LinkerScript::getPhdrIndices(OutputSection *cmd) {
             "' is not listed in PHDRS");
   }
   return ret;
+}
+
+static void checkMemoryRegion(const MemoryRegion *region,
+                              const OutputSection *osec, uint64_t addr) {
+  uint64_t osecEnd = addr + osec->size;
+  uint64_t regionEnd = region->getOrigin() + region->getLength();
+  if (osecEnd > regionEnd) {
+    error("section '" + osec->name + "' will not fit in region '" +
+          region->name + "': overflowed by " + Twine(osecEnd - regionEnd) +
+          " bytes");
+  }
+}
+
+void LinkerScript::checkMemoryRegions() const {
+  for (const OutputSection *sec : outputSections) {
+    if (const MemoryRegion *memoryRegion = sec->memRegion)
+      checkMemoryRegion(memoryRegion, sec, sec->addr);
+    if (const MemoryRegion *lmaRegion = sec->lmaRegion)
+      checkMemoryRegion(lmaRegion, sec, sec->getLMA());
+  }
 }

--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -151,6 +151,9 @@ struct MemoryRegion {
   uint32_t negInvFlags;
   uint64_t curPos = 0;
 
+  uint64_t getOrigin() const { return origin().getValue(); }
+  uint64_t getLength() const { return length().getValue(); }
+
   bool compatibleWith(uint32_t secFlags) const {
     if ((secFlags & negFlags) || (~secFlags & negInvFlags))
       return false;
@@ -332,6 +335,9 @@ public:
 
   // Used to handle INSERT AFTER statements.
   void processInsertCommands();
+
+  // Verify memory/lma overflows.
+  void checkMemoryRegions() const;
 
   // SECTIONS command list.
   SmallVector<SectionCommand *, 0> sectionCommands;

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -2156,6 +2156,8 @@ template <class ELFT> void Writer<ELFT>::finalizeSections() {
   // of finalizing other sections.
   for (OutputSection *sec : outputSections)
     sec->finalize();
+
+  script->checkMemoryRegions();
 }
 
 // Ensure data sections are not mixed with executable sections when

--- a/lld/test/ELF/linkerscript/end-overflow-check.test
+++ b/lld/test/ELF/linkerscript/end-overflow-check.test
@@ -1,0 +1,74 @@
+REQUIRES: x86
+
+# RUN: rm -rf %t && split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64 %t/a.s -o %t/a.o
+
+## The error should be triggered only for the second test where the overflow really exists.
+
+RUN: ld.lld %t/a.o -T %t/b.lds -o /dev/null 2>&1
+RUN: not ld.lld %t/a.o -T %t/c.lds -o /dev/null 2>&1 | FileCheck --check-prefix=ERROR %s
+
+# ERROR: error: section '_abss' will not fit in region 'SRAM0': overflowed by 1024 bytes
+# ERROR: error: section '.c.bss' will not fit in region 'SRAM0': overflowed by 1024 bytes
+# ERROR: error: section '.text' will not fit in region 'SRAM0': overflowed by 1025 bytes
+
+#--- a.s
+.section .a.bss, "aw", %nobits
+.globl abss
+abss:
+.zero 0xDF0
+.size abss, 0xDF0
+
+.section .c.bss, "aw", %nobits
+.globl cbss
+
+.text
+.globl _start
+_start:
+nop
+
+#--- b.lds
+MEMORY
+{
+    SRAM0 (rw) : ORIGIN = 0x20000400, LENGTH = 10K
+}
+
+SECTIONS
+{
+    _abss ALIGN(REGION1__PRE_ALIGNMENT) :
+    {
+        REGION1__BEGIN = .; REGION1__ALIGNED_BEGIN = .; REGION1_ALIGNED_BEGIN = .;
+        *(.a.bss)
+        REGION1__END = .; . = ALIGN(REGION1__POST_ALIGNMENT); REGION1_ALIGNED_END = .;
+    } > SRAM0
+}
+
+REGION1__PRE_ALIGNMENT = 0x00000800;
+REGION1__PADDED_XOR = ((ABSOLUTE(REGION1__ALIGNED_BEGIN) | (ABSOLUTE(REGION1__END) - 1)) & ~(ABSOLUTE(REGION1__ALIGNED_BEGIN) & (ABSOLUTE(REGION1__END) - 1)));
+REGION1__PADDED_REGION_SHIFT = LOG2CEIL(REGION1__PADDED_XOR);
+REGION1__PADDED_SR_SHIFT = REGION1__PADDED_REGION_SHIFT - 3;
+REGION1__PADDED_SR_SIZE = MAX(1 << REGION1__PADDED_SR_SHIFT, 32);
+REGION1__POST_ALIGNMENT = REGION1__PADDED_SR_SIZE;
+
+#--- c.lds
+MEMORY
+{
+    SRAM0 (rw) : ORIGIN = 0x20000400, LENGTH = 4K
+}
+
+SECTIONS
+{
+    _abss ALIGN(REGION1__PRE_ALIGNMENT) :
+    {
+        REGION1__BEGIN = .; REGION1__ALIGNED_BEGIN = .; REGION1_ALIGNED_BEGIN = .;
+        *(.a.bss)
+        REGION1__END = .; . = ALIGN(REGION1__POST_ALIGNMENT); REGION1_ALIGNED_END = .;
+    } > SRAM0
+}
+
+REGION1__PRE_ALIGNMENT = 0x00000800;
+REGION1__PADDED_XOR = ((ABSOLUTE(REGION1__ALIGNED_BEGIN) | (ABSOLUTE(REGION1__END) - 1)) & ~(ABSOLUTE(REGION1__ALIGNED_BEGIN) & (ABSOLUTE(REGION1__END) - 1)));
+REGION1__PADDED_REGION_SHIFT = LOG2CEIL(REGION1__PADDED_XOR);
+REGION1__PADDED_SR_SHIFT = REGION1__PADDED_REGION_SHIFT - 3;
+REGION1__PADDED_SR_SIZE = MAX(1 << REGION1__PADDED_SR_SHIFT, 32);
+REGION1__POST_ALIGNMENT = REGION1__PADDED_SR_SIZE;

--- a/lld/test/ELF/linkerscript/memory-err.s
+++ b/lld/test/ELF/linkerscript/memory-err.s
@@ -62,14 +62,14 @@
 ## ORIGIN/LENGTH can be simple symbolic expressions. If the expression
 ## requires interaction with memory regions, it may fail.
 
-# RUN: echo 'MEMORY { ram : ORIGIN = symbol, LENGTH = 4097 } \
+# RUN: echo 'MEMORY { ram : ORIGIN = symbol, LENGTH = 4094 } \
 # RUN: SECTIONS { \
 # RUN:   .text : { *(.text) } > ram \
 # RUN:   symbol = .; \
 # RUN:   .data : { *(.data) } > ram \
 # RUN: }' > %t.script
 # RUN: not ld.lld -T %t.script %t.o -o /dev/null 2>&1 | FileCheck --check-prefix=ERR_OVERFLOW %s
-# ERR_OVERFLOW: error: section '.text' will not fit in region 'ram': overflowed by 18446744073709547518 bytes
+# ERR_OVERFLOW: error: section '.data' will not fit in region 'ram': overflowed by 2 bytes
 
 nop
 

--- a/lld/test/ELF/linkerscript/memory-nonalloc-no-warn.test
+++ b/lld/test/ELF/linkerscript/memory-nonalloc-no-warn.test
@@ -1,0 +1,59 @@
+# REQUIRES: x86
+
+# RUN: split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64 %t/a.s -o %t/a.o
+
+## Check if the linker can generate the final file, containing all non-empty sections,
+## without warnings for .intvec0_out, .intvec1_out1, .intvec2_out, because their
+## input sections are empty. Althoung, the linker must generate a warning for the
+## first ".nonalloc" section and the second .dat, as expected.
+
+# RUN: ld.lld %t/a.o -T %t/a.lds -o %t/a.elf 2>&1 | FileCheck %s --check-prefix=WARN --implicit-check-not=warning:
+
+# WARN: warning: ignoring memory region assignment for non-allocatable section '.nonalloc'
+# WARN: warning: ignoring memory region assignment for non-allocatable section '.dat'
+
+## The output file must include all sections.
+# RUN: llvm-readelf -S %t/a.elf | FileCheck %s
+
+# CHECK:      There are 12 section headers, starting at offset 0x2140:
+# CHECK:      [Nr] Name         Type      Address          Off    Size   ES Flg Lk Inf Al
+# CHECK-NEXT: [ 0]              NULL      0000000000000000 000000 000000 00     0  0   0
+# CHECK-NEXT: [ 1] .nonalloc    PROGBITS  0000000000000000 001064 001000 00 W   0  0   1
+# CHECK-NEXT: [ 2] .comment     PROGBITS  0000000000000000 {{.*}} {{.*}} 01 MS  0  0   1
+# CHECK-NEXT: [ 3] .symtab      SYMTAB    0000000000000000 {{.*}} {{.*}} 18     5  1   8
+# CHECK-NEXT: [ 4] .shstrtab    STRTAB    0000000000000000 {{.*}} {{.*}} 00     0  0   1
+# CHECK-NEXT: [ 5] .strtab      STRTAB    0000000000000000 {{.*}} {{.*}} 00     0  0   1
+# CHECK-NEXT: [ 6] .dat         PROGBITS  0000000000000000 002137 000004 00 W   0  0   1
+# CHECK-NEXT: [ 7] .intvec0_out PROGBITS  0000000000000000 00213b 000000 00 W   0  0   1
+# CHECK-NEXT: [ 8] .intvec1_out PROGBITS  0000000000000000 00213b 000000 00 W   0  0   1
+# CHECK-NEXT: [ 9] .intvec2_out PROGBITS  0000000000000000 00213b 000000 00 W   0  0   1
+# CHECK-NEXT: [10] .intvec3_out PROGBITS  00000000803fe060 001060 000004 00 AX  0  0   1
+# CHECK-NEXT: [11] .text        PROGBITS  00000000803fe064 001064 000000 00 AX  0  0   4
+
+
+#--- a.s
+.global _start
+.text
+_start:
+.section .nonalloc,"w"
+.zero 0x1000
+.section .intvec3,"ax",@progbits
+.long 1
+
+#--- a.lds
+MEMORY {
+  MEM1 : ORIGIN = 0x10000000, LENGTH = 1M
+  MEM2 (rx) : ORIGIN = 0x80000000, LENGTH = 4M
+}
+
+VEC_START = 0x803FE000;
+
+SECTIONS {
+ .nonalloc : { *(.nonalloc) } > MEM
+ .dat : { LONG(0); } > MEM1
+ .intvec0_out (VEC_START + 0x0000) : {KEEP (*(.intvec1)) } > MEM2
+ .intvec1_out (VEC_START + 0x0020) : {KEEP (*(.intvec1)) } > MEM2
+ .intvec2_out (VEC_START + 0x0040) : {KEEP (*(.intvec2)) } > MEM2
+ .intvec3_out (VEC_START + 0x0060) : {KEEP (*(.intvec3)) } > MEM2
+}


### PR DESCRIPTION
Backport the lld overflow check fixes, so the opentitan ROM can use lld for linking (and enable LTO when compiling with clang). The upstream patch required some conflict resolution, but this variant did succeed in building the ROM for me.

This also includes a backport of an unrelated refinement of warnings related to non-allocatable sections. This commit can probably be dropped, if desired. Its patch did apply cleanly.