### PR TITLE
[InstrProf] Fix single byte counters for elided branches

### DIFF
--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -800,12 +800,23 @@ void CodeGenFunction::EmitIfStmt(const IfStmt &S) {
     // If the skipped block has no labels in it, just emit the executed block.
     // This avoids emitting dead code and simplifies the CFG substantially.
     if (S.isConstexpr() || !ContainsLabel(Skipped)) {
-      if (CondConstant)
+      if (CondConstant && !llvm::EnableSingleByteCoverage)
         incrementProfileCounter(&S);
+
       if (Executed) {
+        // When single byte coverage mode is enabled, add a counter to the
+        // executed block.
+        if (llvm::EnableSingleByteCoverage)
+          incrementProfileCounter(Executed);
         RunCleanupsScope ExecutedScope(*this);
         EmitStmt(Executed);
       }
+
+      // When single byte coverage mode is enabled, add a counter to
+      // continuation block.
+      if (llvm::EnableSingleByteCoverage)
+        incrementProfileCounter(&S);
+
       return;
     }
   }


### PR DESCRIPTION
Single byte counters for elided branches in `CGStmt::EmitIfStmt` were not correctly incremented. In normal mode, the counter bound to the `IfStmt` counts the `then` arm, but in single-byte mode, it's intended to count the continuation block.

This patch adds the necessary increments for single-byte coverage mode in the elided branch case.

###  Reproducer
#### Before
```c
 Line   Count
    1|      1|int main() {
    2|      1|  if (1) {
    3|      0|    return 0;
    4|      0|  }
    5|      1|  return 0;
    6|      1|}
```

#### After
```c
 Line   Count
    1|      1|int main() {
    2|      1|  if (1) {
    3|      1|    return 0;
    4|      1|  }
    5|      0|  return 0;
    6|      1|}
```